### PR TITLE
Quick fix for non-updating LaTeX view (#24)

### DIFF
--- a/Sources/LaTeXSwiftUI/LaTeX.swift
+++ b/Sources/LaTeXSwiftUI/LaTeX.swift
@@ -125,7 +125,7 @@ public struct LaTeX: View {
   // MARK: Public properties
   
   /// The view's LaTeX input string.
-  public let latex: String
+  @Binding public var latex: String
   
   // MARK: Environment variables
   
@@ -163,16 +163,22 @@ public struct LaTeX: View {
   
   /// The view's preload task, if any.
   @State private var preloadTask: Task<(), Never>?
+    
+    @State private var compos = [ComponentBlock]()
   
   // MARK: Initializers
   
   /// Initializes a view with a LaTeX input string.
   ///
   /// - Parameter latex: The LaTeX input.
-  public init(_ latex: String) {
-    self.latex = latex
-    _renderer = StateObject(wrappedValue: Renderer(latex: latex))
+  public init(_ latex: Binding<String>) {
+    _latex = latex
+    _renderer = StateObject(wrappedValue: Renderer())
   }
+    
+    public init(_ latex: String) {
+        self.init(.constant(latex))
+    }
   
   // MARK: View body
   
@@ -194,7 +200,7 @@ public struct LaTeX: View {
           loadingView().task(renderAsync)
         case .wait:
           // Render the components synchronously
-          bodyWithBlocks(renderSync())
+            bodyWithBlocks(renderSync())
         }
       }
     }
@@ -244,7 +250,9 @@ extension LaTeX {
       processEscapes: processEscapes,
       errorMode: errorMode,
       font: font ?? .body,
-      displayScale: displayScale)
+      displayScale: displayScale,
+      latex: latex
+    )
   }
   
   /// Renders the view's components.
@@ -255,20 +263,24 @@ extension LaTeX {
       processEscapes: processEscapes,
       errorMode: errorMode,
       font: font ?? .body,
-      displayScale: displayScale)
+      displayScale: displayScale,
+      latex: latex
+    )
   }
   
   /// Renders the view's components synchronously.
   ///
   /// - Returns: The rendered components.
   private func renderSync() -> [ComponentBlock] {
-    renderer.renderSync(
+      renderer.renderSync(
       unencodeHTML: unencodeHTML,
       parsingMode: parsingMode,
       processEscapes: processEscapes,
       errorMode: errorMode,
       font: font ?? .body,
-      displayScale: displayScale)
+      displayScale: displayScale,
+      latex: latex
+      )
   }
   
   /// Creates the view's body based on its block mode.

--- a/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Color.swift
+++ b/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Color.swift
@@ -29,7 +29,7 @@ struct LaTeX_Previews_Color: PreviewProvider {
   
   static var previews: some View {
     VStack {
-      LaTeX("Hello, $\\LaTeX$!")
+        LaTeX("Hello, $\\LaTeX$!")
         .font(.largeTitle)
         .foregroundStyle(
           LinearGradient(

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlockText.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlockText.swift
@@ -72,6 +72,6 @@ struct ComponentBlockTextPreviews: PreviewProvider {
   static var previews: some View {
     ComponentBlockText(block: ComponentBlock(components: [
       Component(text: "Hello, World!", type: .text)
-    ]), renderer: Renderer(latex: "Hello, World!"))
+    ]), renderer: Renderer())
   }
 }

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
@@ -57,6 +57,6 @@ struct ComponentBlocksTextPreviews: PreviewProvider {
     ComponentBlocksText(blocks: [ComponentBlock(components: [
       Component(text: "Hello, World!", type: .text)
     ])], forceInline: false)
-    .environmentObject(Renderer(latex: "Hello, World!"))
+    .environmentObject(Renderer())
   }
 }

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
@@ -97,6 +97,6 @@ struct ComponentBlocksViewsPreviews: PreviewProvider {
     ComponentBlocksViews(blocks: [ComponentBlock(components: [
       Component(text: "Hello, World!", type: .text)
     ])])
-    .environmentObject(Renderer(latex: "Hello, World!"))
+    .environmentObject(Renderer())
   }
 }


### PR DESCRIPTION
Since this issue #24 is critical, I have found a way to update the view when a `@State` string is passed to `LaTeX`. This is basically what I did:

- Made the `latex` property from `LaTeX` a `@Binding`
- Removed the `latex` property from `Renderer` but made the `latex` string a parameter of the rendering methods
- Modified `Renderer.parsedBlocks` so that it *always* parses new blocks when the LaTeX string is changed
- Added another `init` for `LaTeX` so that one can pass a `@State` property without using `$`

This is a quick fix since this kinda breaks optimisation with cache and stuff. It certainly will not be an issue for small renders, but a real fix is needed.