### PR TITLE
Add tvOS platform support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
   platforms: [
     .iOS(.v15),
     .macOS(.v12),
+    .tvOS(.v15),
     .visionOS(.v1)
   ],
   products: [

--- a/Sources/LaTeXSwiftUI/Extensions/Font+Extensions.swift
+++ b/Sources/LaTeXSwiftUI/Extensions/Font+Extensions.swift
@@ -26,7 +26,7 @@
 import Foundation
 import SwiftUI
 
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
 import UIKit
 #else
 import Cocoa
@@ -39,7 +39,12 @@ internal extension Font {
   /// The font's text style.
   func textStyle() -> _Font.TextStyle? {
     switch self {
-    case .largeTitle, .largeTitle.bold(), .largeTitle.italic(), .largeTitle.monospaced(): return .largeTitle
+    case .largeTitle, .largeTitle.bold(), .largeTitle.italic(), .largeTitle.monospaced():
+    #if os(tvOS)
+    return .title1
+    #else
+    return .largeTitle
+    #endif
     case .title, .title.bold(), .title.italic(), .title.monospaced(): return .title1
     case .title2, .title2.bold(), .title2.italic(), .title.monospaced(): return .title2
     case .title3, .title3.bold(), .title3.italic(), .title.monospaced(): return .title3
@@ -90,7 +95,7 @@ internal extension _Font {
   /// - Returns: The preferred font.
   class func preferredFont(from font: Font, sizeCategory: DynamicTypeSize? = nil) -> _Font {
     guard let textStyle = font.textStyle() else {
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
       if let sizeCategory {
         let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
         return _Font.preferredFont(forTextStyle: .body, compatibleWith: traits)
@@ -98,7 +103,7 @@ internal extension _Font {
 #endif
       return _Font.preferredFont(forTextStyle: .body)
     }
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
     let _font: _Font
     if let sizeCategory {
       let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
@@ -135,7 +140,7 @@ internal extension _Font {
         .caption2.bold(),
         .footnote.bold(),
         .body.bold():
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitBold) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -158,7 +163,7 @@ internal extension _Font {
         .caption2.monospaced(),
         .footnote.monospaced(),
         .body.monospaced():
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitMonoSpace) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -181,7 +186,7 @@ internal extension _Font {
         .caption2.italic(),
         .footnote.italic(),
         .body.italic():
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitItalic) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -194,7 +199,7 @@ internal extension _Font {
 #endif
       
     default:
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
       if let sizeCategory {
         let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
         return _Font.preferredFont(forTextStyle: .body, compatibleWith: traits)
@@ -206,7 +211,7 @@ internal extension _Font {
 
 }
 
-#if os(iOS) || os(visionOS) || os(tvOS)
+#if os(iOS) || os(visionOS) || os(tvOS) || os(tvOS)
 extension UIContentSizeCategory {
 
   /// Creates a `UIContentSizeCategory` from a SwiftUI `DynamicTypeSize`.

--- a/Sources/LaTeXSwiftUI/Extensions/Font+Extensions.swift
+++ b/Sources/LaTeXSwiftUI/Extensions/Font+Extensions.swift
@@ -26,7 +26,7 @@
 import Foundation
 import SwiftUI
 
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
 import UIKit
 #else
 import Cocoa
@@ -90,7 +90,7 @@ internal extension _Font {
   /// - Returns: The preferred font.
   class func preferredFont(from font: Font, sizeCategory: DynamicTypeSize? = nil) -> _Font {
     guard let textStyle = font.textStyle() else {
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
       if let sizeCategory {
         let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
         return _Font.preferredFont(forTextStyle: .body, compatibleWith: traits)
@@ -98,7 +98,7 @@ internal extension _Font {
 #endif
       return _Font.preferredFont(forTextStyle: .body)
     }
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
     let _font: _Font
     if let sizeCategory {
       let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
@@ -135,7 +135,7 @@ internal extension _Font {
         .caption2.bold(),
         .footnote.bold(),
         .body.bold():
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitBold) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -158,7 +158,7 @@ internal extension _Font {
         .caption2.monospaced(),
         .footnote.monospaced(),
         .body.monospaced():
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitMonoSpace) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -181,7 +181,7 @@ internal extension _Font {
         .caption2.italic(),
         .footnote.italic(),
         .body.italic():
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
       if let descriptor = _font.fontDescriptor.withSymbolicTraits(.traitItalic) {
         return _Font(descriptor: descriptor, size: _font.pointSize)
       }
@@ -194,7 +194,7 @@ internal extension _Font {
 #endif
       
     default:
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
       if let sizeCategory {
         let traits = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory(sizeCategory))
         return _Font.preferredFont(forTextStyle: .body, compatibleWith: traits)
@@ -206,7 +206,7 @@ internal extension _Font {
 
 }
 
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
 extension UIContentSizeCategory {
 
   /// Creates a `UIContentSizeCategory` from a SwiftUI `DynamicTypeSize`.

--- a/Sources/LaTeXSwiftUI/Extensions/Image+Extensions.swift
+++ b/Sources/LaTeXSwiftUI/Extensions/Image+Extensions.swift
@@ -27,7 +27,7 @@ import SwiftUI
 internal extension Image {
   
   init(image: _Image, scale: CGFloat = 1.0) {
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
     self.init(uiImage: image)
 #else
     if scale > 1.0 {

--- a/Sources/LaTeXSwiftUI/LaTeX.swift
+++ b/Sources/LaTeXSwiftUI/LaTeX.swift
@@ -271,7 +271,7 @@ extension LaTeX {
     Task { await preloadTask?.value }
   }
   
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
   public func font(_ font: UIFont) -> some View {
     self
       .platformFont(font)
@@ -300,7 +300,7 @@ extension LaTeX {
   ///   - processEscapes: Whether to process escape sequences (default: false).
   ///   - errorMode: The error mode (default: `.rendered`).
   /// - Returns: An array of rendered images, one per equation.
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
   public static func renderToImages(
     _ latex: String,
     xHeight: CGFloat? = nil,

--- a/Sources/LaTeXSwiftUI/Models/Aliases.swift
+++ b/Sources/LaTeXSwiftUI/Models/Aliases.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
 import UIKit
 internal typealias _Image = UIImage
 internal typealias _Font = UIFont

--- a/Sources/LaTeXSwiftUI/Models/Component.swift
+++ b/Sources/LaTeXSwiftUI/Models/Component.swift
@@ -247,7 +247,7 @@ extension Component {
         let offset = svg.geometry.verticalAlignment.toPoints(xHeight)
         let baselineOffset = blockRenderingMode == .alwaysInline || !isInEquationBlock ? offset : 0
         var imageText: Text
-        if #available(iOS 18.0, macOS 15.0, *) {
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
           imageText = Text(imageContainer.image)
             .baselineOffset(baselineOffset)
             .customAttribute(EquationMarker())

--- a/Sources/LaTeXSwiftUI/Models/EquationMarker.swift
+++ b/Sources/LaTeXSwiftUI/Models/EquationMarker.swift
@@ -26,5 +26,5 @@
 import SwiftUI
 
 /// Marks a text run as containing a rendered equation image.
-@available(iOS 18.0, macOS 15.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 internal struct EquationMarker: TextAttribute {}

--- a/Sources/LaTeXSwiftUI/Models/Renderer.swift
+++ b/Sources/LaTeXSwiftUI/Models/Renderer.swift
@@ -28,7 +28,7 @@ import MathJaxSwift
 import SwiftDraw
 import SwiftUI
 
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(tvOS)
 import UIKit
 #else
 import Cocoa
@@ -605,7 +605,7 @@ extension Renderer {
 
     guard let cgImage = ctx.makeImage() else { return nil }
 
-    #if os(iOS) || os(visionOS)
+    #if os(iOS) || os(visionOS) || os(tvOS)
     return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
     #else
     return NSImage(cgImage: cgImage, size: size)

--- a/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Dynamic.swift
+++ b/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Dynamic.swift
@@ -34,7 +34,11 @@ struct LaTeX_Previews_Dynamic: PreviewProvider {
     var body: some View {
       VStack(spacing: 16) {
         TextField("Enter LaTeX", text: $text)
+          #if os(tvOS)
+          .textFieldStyle(.plain)
+          #else
           .textFieldStyle(.roundedBorder)
+          #endif
 
         LaTeX("$\(text)$")
       }

--- a/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Fonts.swift
+++ b/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Fonts.swift
@@ -25,7 +25,7 @@
 
 import SwiftUI
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 typealias PlatformFont = UIFont
 #else

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
@@ -74,7 +74,7 @@ internal struct ComponentBlocksText: View {
       Text("\n") + text(for: block) + Text("\n") :
       text(for: block)
     }.reduce(Text(""), +)
-    if #available(iOS 18.0, macOS 15.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       textView.textRenderer(LineSpacingNormalizer())
     } else {
       textView

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
@@ -103,7 +103,7 @@ internal struct ComponentBlocksViews: View {
             blockRenderingMode: blockMode,
             ignoreStringFormatting: ignoreStringFormatting,
             imageAccessibilityMode: imageAccessibilityMode)
-          if #available(iOS 18.0, macOS 15.0, *) {
+          if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
             textView.textRenderer(LineSpacingNormalizer())
           } else {
             textView

--- a/Sources/LaTeXSwiftUI/Views/LineSpacingNormalizer.swift
+++ b/Sources/LaTeXSwiftUI/Views/LineSpacingNormalizer.swift
@@ -31,7 +31,7 @@ import SwiftUI
 /// Works by computing baseline-to-baseline distances between adjacent lines,
 /// finding the minimum (the natural text-only spacing), and shifting inflated
 /// lines closer while clamping to prevent overlap.
-@available(iOS 18.0, macOS 15.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 internal struct LineSpacingNormalizer: TextRenderer {
 
   func draw(layout: Text.Layout, in context: inout GraphicsContext) {


### PR DESCRIPTION
## Summary

- Adds `.tvOS(.v15)` to Package.swift platform targets
- Includes `os(tvOS)` in all `#if os(iOS) || os(visionOS)` conditional compilation checks across 9 source files
- Adds `tvOS 18.0` to `@available` annotations for TextRenderer/TextAttribute APIs (EquationMarker, LineSpacingNormalizer)

## Rationale

All three dependencies already support tvOS:
- **MathJaxSwift 3.5.0** — declares `.tvOS(.v13)`
- **SwiftDraw 0.27.0** — declares `.tvOS(.v13)`
- **swift-html-entities 4.0.1** — no platform restrictions

Since tvOS uses UIKit, the existing iOS/visionOS code paths (UIImage, UIFont, UIColor, UITraitCollection, UIContentSizeCategory, font descriptor traits) all apply directly with no behavioral changes needed.

This follows the same pattern as #41 which added visionOS support.

## Test plan

- [ ] Build for tvOS simulator target in Xcode
- [ ] Run existing test suite against tvOS
- [ ] Verify LaTeX rendering in a sample tvOS app

🤖 Generated with [Claude Code](https://claude.com/claude-code)