### PR TITLE
Fix visionOS build (Cocoa import + visionOS 2.0 availability)

### DIFF
--- a/Sources/LaTeXSwiftUI/Models/Component.swift
+++ b/Sources/LaTeXSwiftUI/Models/Component.swift
@@ -247,7 +247,7 @@ extension Component {
         let offset = svg.geometry.verticalAlignment.toPoints(xHeight)
         let baselineOffset = blockRenderingMode == .alwaysInline || !isInEquationBlock ? offset : 0
         var imageText: Text
-        if #available(iOS 18.0, macOS 15.0, *) {
+        if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
           imageText = Text(imageContainer.image)
             .baselineOffset(baselineOffset)
             .customAttribute(EquationMarker())

--- a/Sources/LaTeXSwiftUI/Models/EquationMarker.swift
+++ b/Sources/LaTeXSwiftUI/Models/EquationMarker.swift
@@ -26,5 +26,5 @@
 import SwiftUI
 
 /// Marks a text run as containing a rendered equation image.
-@available(iOS 18.0, macOS 15.0, *)
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 internal struct EquationMarker: TextAttribute {}

--- a/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Fonts.swift
+++ b/Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Fonts.swift
@@ -25,7 +25,7 @@
 
 import SwiftUI
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import UIKit
 typealias PlatformFont = UIFont
 #else

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksText.swift
@@ -74,7 +74,7 @@ internal struct ComponentBlocksText: View {
       Text("\n") + text(for: block) + Text("\n") :
       text(for: block)
     }.reduce(Text(""), +)
-    if #available(iOS 18.0, macOS 15.0, *) {
+    if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
       textView.textRenderer(LineSpacingNormalizer())
     } else {
       textView

--- a/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
+++ b/Sources/LaTeXSwiftUI/Views/ComponentBlocksViews.swift
@@ -103,7 +103,7 @@ internal struct ComponentBlocksViews: View {
             blockRenderingMode: blockMode,
             ignoreStringFormatting: ignoreStringFormatting,
             imageAccessibilityMode: imageAccessibilityMode)
-          if #available(iOS 18.0, macOS 15.0, *) {
+          if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
             textView.textRenderer(LineSpacingNormalizer())
           } else {
             textView

--- a/Sources/LaTeXSwiftUI/Views/LineSpacingNormalizer.swift
+++ b/Sources/LaTeXSwiftUI/Views/LineSpacingNormalizer.swift
@@ -31,7 +31,7 @@ import SwiftUI
 /// Works by computing baseline-to-baseline distances between adjacent lines,
 /// finding the minimum (the natural text-only spacing), and shifting inflated
 /// lines closer while clamping to prevent overlap.
-@available(iOS 18.0, macOS 15.0, *)
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 internal struct LineSpacingNormalizer: TextRenderer {
 
   func draw(layout: Text.Layout, in context: inout GraphicsContext) {


### PR DESCRIPTION
## Summary

LaTeXSwiftUI does not build for **visionOS**, which breaks any visionOS target that depends on it. There are two independent causes; this PR fixes both.

### 1. Unguarded `import Cocoa` in a previews file

`Sources/LaTeXSwiftUI/Previews/LaTeX_Previews+Fonts.swift` selected its font type with:

```swift
#if os(iOS)
import UIKit
typealias PlatformFont = UIFont
#else
import Cocoa            // visionOS lands here — Cocoa doesn't exist on visionOS
typealias PlatformFont = NSFont
#endif
```

On visionOS `os(iOS)` is false, so it falls into `#else` and tries `import Cocoa`:

```
error: Unable to resolve module dependency: 'Cocoa'
```

Fix: `#if os(iOS) || os(visionOS)`. This was the **only** UIKit/Cocoa guard in the package missing `|| os(visionOS)` — every other site (`Font+Extensions.swift`, `Models/Renderer.swift`, `Models/Aliases.swift`, `Extensions/Image+Extensions.swift`, `LaTeX.swift`) already uses it. `UIFont` is available on visionOS, so the UIKit branch is correct.

### 2. visionOS-2.0 text-attribute path not gated for visionOS

`EquationMarker` conforms to SwiftUI's `TextAttribute`, which — with `Text.customAttribute` — is available on **iOS 18 / macOS 15 / visionOS 2.0**. Five availability clauses spelled that generation as `(iOS 18.0, macOS 15.0, *)`, omitting visionOS. Since the package's deployment floor is `.visionOS(.v1)`, the `*` resolves to visionOS 1.0 and the compiler rejects the symbol:

```
error: 'EquationMarker' is only available in visionOS 2.0 or newer
```

Fix: add `visionOS 2.0` to all five clauses:

- `Models/EquationMarker.swift` (`@available`)
- `Views/LineSpacingNormalizer.swift` (`@available`)
- `Views/ComponentBlocksViews.swift` (`#available`)
- `Views/ComponentBlocksText.swift` (`#available`)
- `Models/Component.swift` (`#available`)

The existing `else` branches still cover visionOS 1.x, so the package keeps its visionOS 1.0 floor (no `Package.swift` platform bump needed).

## Scope / impact

- No behavior change on iOS or macOS.
- Restores compilation on visionOS (verified building a visionOS app that depends on LaTeXSwiftUI with Xcode 27 / the visionOS 27 SDK).
- Present on `main`, `develop`, and `v2.1` at time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)